### PR TITLE
feat(can): Add CAN Bus SocketCAN support

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -506,10 +506,28 @@ jobs:
           cmake \
           ninja-build \
           lcov \
-          valgrind
+          valgrind \
+          iproute2
+
+    - name: Setup vcan interface for SocketCAN tests
+      run: |
+        # Load vcan kernel module (may not be available on all runners)
+        if sudo modprobe vcan 2>/dev/null; then
+          sudo ip link add dev vcan0 type vcan
+          sudo ip link set up vcan0
+          echo "SOCKETCAN_AVAILABLE=true" >> $GITHUB_ENV
+          echo "SocketCAN vcan0 interface ready"
+        else
+          echo "SOCKETCAN_AVAILABLE=false" >> $GITHUB_ENV
+          echo "vcan kernel module not available - SocketCAN tests will be skipped"
+        fi
 
     - name: Configure CMake (C++${{ matrix.cpp_standard }})
       run: |
+        SOCKETCAN_FLAG=OFF
+        if [ "$SOCKETCAN_AVAILABLE" = "true" ]; then
+          SOCKETCAN_FLAG=ON
+        fi
         cmake -B build \
           -G Ninja \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
@@ -517,6 +535,7 @@ jobs:
           -DCMAKE_CXX_STANDARD_REQUIRED=ON \
           -DCMAKE_C_COMPILER=gcc \
           -DCMAKE_CXX_COMPILER=g++ \
+          -DENABLE_SOCKETCAN=${SOCKETCAN_FLAG} \
           -DBUILD_SHARED_LIBS=ON \
           -DBUILD_STATIC_LIBS=ON \
           -DBUILD_EXECUTABLE=ON \
@@ -581,6 +600,24 @@ jobs:
         ./test.sh
 
         echo "✅ All integration tests passed"
+
+    - name: Run SocketCAN integration tests
+      if: matrix.config == 'Debug' && env.SOCKETCAN_AVAILABLE == 'true'
+      run: |
+        export LD_LIBRARY_PATH="${{ github.workspace }}/install/lib:${LD_LIBRARY_PATH:-}"
+        cd install/test
+        if [ -f ./test_can.sh ]; then
+          chmod +x ./test_can.sh
+          ./test_can.sh
+        else
+          echo "test_can.sh not found - skipping CAN tests"
+        fi
+
+    - name: Cleanup vcan interface
+      if: always() && env.SOCKETCAN_AVAILABLE == 'true'
+      run: |
+        sudo ip link set down vcan0 2>/dev/null || true
+        sudo ip link delete vcan0 2>/dev/null || true
 
     - name: Run valgrind memory check (Debug only)
       if: matrix.config == 'Debug' && matrix.os == 'ubuntu-24.04'

--- a/install/test/test_can.sh
+++ b/install/test/test_can.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# CAN Bus / SocketCAN Integration Tests
+#
+# Tests the SocketCAN transport layer for receiving ASTERIX data over CAN bus.
+# Requires Linux with vcan kernel module support.
+#
+# Usage: ./test_can.sh
+#
+
+failedtests=0
+passedtests=0
+skippedtests=0
+
+exec="../bin/asterix"
+config="../share/asterix/config/asterix.ini"
+
+# Verify executable exists
+if [ ! -f "${exec}" ]; then
+    echo "Error: Executable not found at ${exec}"
+    echo "Current directory: $(pwd)"
+    exit 1
+fi
+
+pass_test() {
+    echo "OK       $1"
+    passedtests=$((passedtests + 1))
+}
+
+fail_test() {
+    echo "FAILED   $1"
+    failedtests=$((failedtests + 1))
+}
+
+skip_test() {
+    echo "SKIPPED  $1"
+    skippedtests=$((skippedtests + 1))
+}
+
+echo "=========================================="
+echo "  CAN Bus / SocketCAN Integration Tests"
+echo "=========================================="
+echo ""
+
+# Test 1: Check if SocketCAN support is compiled in
+echo "--- Test 1: SocketCAN compile-time support ---"
+if ${exec} --help 2>&1 | grep -qi "can"; then
+    pass_test "SocketCAN support compiled in"
+    CAN_COMPILED=1
+else
+    skip_test "SocketCAN support not compiled in (rebuild with -DENABLE_SOCKETCAN=ON)"
+    CAN_COMPILED=0
+fi
+
+# If CAN is not compiled in, skip remaining tests
+if [ "${CAN_COMPILED}" -eq 0 ]; then
+    echo ""
+    echo "=========================================="
+    echo "  CAN tests skipped (not compiled in)"
+    echo "  Passed: ${passedtests}  Failed: ${failedtests}  Skipped: ${skippedtests}"
+    echo "=========================================="
+    exit 0
+fi
+
+# Test 2: Check CAN argument is accepted (should fail gracefully without interface)
+echo "--- Test 2: CAN argument parsing ---"
+output=$(${exec} -d ${config} -c nonexistent_iface -j 2>&1)
+exitcode=$?
+# We expect a failure (non-zero exit) because the interface does not exist,
+# but it should NOT fail with "unknown option" or "not compiled in"
+if echo "${output}" | grep -qi "not compiled in"; then
+    fail_test "CAN argument rejected as not compiled in"
+elif echo "${output}" | grep -qi "unknown"; then
+    fail_test "CAN argument not recognized"
+else
+    pass_test "CAN argument accepted by CLI parser"
+fi
+
+# Test 3: Check vcan kernel module availability
+echo "--- Test 3: vcan kernel module availability ---"
+VCAN_AVAILABLE=0
+if [ "$(uname -s)" != "Linux" ]; then
+    skip_test "Not on Linux - vcan not available"
+elif ! modinfo vcan > /dev/null 2>&1; then
+    skip_test "vcan kernel module not available (WSL2 or minimal kernel)"
+else
+    pass_test "vcan kernel module available"
+    VCAN_AVAILABLE=1
+fi
+
+# Test 4: Setup vcan0 interface and test device initialization
+echo "--- Test 4: vcan0 interface setup and device init ---"
+VCAN_SETUP=0
+if [ "${VCAN_AVAILABLE}" -eq 0 ]; then
+    skip_test "vcan not available - skipping device init test"
+else
+    # Try to load vcan module and create interface
+    sudo modprobe vcan 2>/dev/null
+    sudo ip link add dev vcan0 type vcan 2>/dev/null
+    sudo ip link set up vcan0 2>/dev/null
+
+    if ip link show vcan0 > /dev/null 2>&1; then
+        VCAN_SETUP=1
+        pass_test "vcan0 interface created and up"
+    else
+        skip_test "Failed to create vcan0 (insufficient privileges)"
+    fi
+fi
+
+# Test 5: Attempt CAN device connection on vcan0
+echo "--- Test 5: CAN device connection test ---"
+if [ "${VCAN_SETUP}" -eq 0 ]; then
+    skip_test "vcan0 not available - skipping connection test"
+else
+    # Run asterix with CAN input on vcan0, with a short timeout
+    # It should open the socket successfully but timeout waiting for data
+    timeout 2 ${exec} -d ${config} -c vcan0 -j 2>&1
+    exitcode=$?
+    # timeout returns 124 on timeout, which means the process started successfully
+    # and was waiting for data (expected behavior)
+    if [ ${exitcode} -eq 124 ]; then
+        pass_test "CAN device opened vcan0 successfully (timed out waiting for data)"
+    elif [ ${exitcode} -eq 0 ]; then
+        pass_test "CAN device connected to vcan0"
+    else
+        fail_test "CAN device failed to open vcan0 (exit code: ${exitcode})"
+    fi
+fi
+
+# Test 6: CAN FD mode argument parsing
+echo "--- Test 6: CAN FD argument format ---"
+if [ "${VCAN_SETUP}" -eq 0 ]; then
+    skip_test "vcan0 not available - skipping FD test"
+else
+    timeout 2 ${exec} -d ${config} -c vcan0:fd -j 2>&1
+    exitcode=$?
+    if [ ${exitcode} -eq 124 ] || [ ${exitcode} -eq 0 ]; then
+        pass_test "CAN FD mode argument accepted"
+    else
+        fail_test "CAN FD mode argument rejected (exit code: ${exitcode})"
+    fi
+fi
+
+# Test 7: CAN with timeout parameter
+echo "--- Test 7: CAN timeout parameter ---"
+if [ "${VCAN_SETUP}" -eq 0 ]; then
+    skip_test "vcan0 not available - skipping timeout test"
+else
+    timeout 2 ${exec} -d ${config} -c vcan0:classic:2000 -j 2>&1
+    exitcode=$?
+    if [ ${exitcode} -eq 124 ] || [ ${exitcode} -eq 0 ]; then
+        pass_test "CAN timeout parameter accepted"
+    else
+        fail_test "CAN timeout parameter rejected (exit code: ${exitcode})"
+    fi
+fi
+
+# Cleanup: Remove vcan0 interface
+if [ "${VCAN_SETUP}" -eq 1 ]; then
+    echo ""
+    echo "--- Cleanup ---"
+    sudo ip link set down vcan0 2>/dev/null
+    sudo ip link delete vcan0 2>/dev/null
+    echo "vcan0 interface removed"
+fi
+
+# Summary
+echo ""
+echo "=========================================="
+echo "  CAN Bus Test Summary"
+echo "  Passed: ${passedtests}  Failed: ${failedtests}  Skipped: ${skippedtests}"
+echo "=========================================="
+
+if [ ${failedtests} -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/openspec/changes/add-can-socketcan-support/tasks.md
+++ b/openspec/changes/add-can-socketcan-support/tasks.md
@@ -66,10 +66,10 @@ _Validated 2026-02-07: All design references confirmed accurate. Gaps addressed 
 **File**: `src/main/asterix.cpp`
 **Validation**: `./asterix -c vcan0 -j` attempts to open vcan0
 
-- [ ] Add `strCANInput` variable
-- [ ] Add `-c`/`--can` argument parsing
-- [ ] Add help text explaining format: `interface[:fd[:timeout]]`
-- [ ] Build input string for CAN device in `buildInputString()`
+- [x] Add `strCANInput` variable
+- [x] Add `-c`/`--can` argument parsing
+- [x] Add help text explaining format: `interface[:fd[:timeout]]`
+- [x] Build input string for CAN device in `buildInputString()`
 
 ---
 
@@ -79,20 +79,20 @@ _Validated 2026-02-07: All design references confirmed accurate. Gaps addressed 
 **File**: `install/test/test_can.sh`
 **Validation**: Script runs without errors on GitHub Actions
 
-- [ ] Check if SocketCAN compiled in (`--help | grep socketcan`)
-- [ ] Setup vcan0 interface (requires sudo)
-- [ ] Basic device initialization test
-- [ ] Cleanup vcan0 interface
-- [ ] Skip gracefully if vcan not available (WSL2)
+- [x] Check if SocketCAN compiled in (`--help | grep socketcan`)
+- [x] Setup vcan0 interface (requires sudo)
+- [x] Basic device initialization test
+- [x] Cleanup vcan0 interface
+- [x] Skip gracefully if vcan not available (WSL2)
 
 ### Task 4.2: Add CI workflow support
 **File**: `.github/workflows/cross-platform-builds.yml` (Linux jobs only)
 **Validation**: CI runs CAN tests on Linux Ubuntu runners
 
-- [ ] Add vcan kernel module setup step (`sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`)
-- [ ] Add `-DENABLE_SOCKETCAN=ON` to CMake configure for Linux jobs
-- [ ] Run test_can.sh in test phase
-- [ ] Skip CAN tests on Windows and macOS jobs
+- [x] Add vcan kernel module setup step (`sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`)
+- [x] Add `-DENABLE_SOCKETCAN=ON` to CMake configure for Linux jobs
+- [x] Run test_can.sh in test phase
+- [x] Skip CAN tests on Windows and macOS jobs
 
 ---
 
@@ -101,10 +101,10 @@ _Validated 2026-02-07: All design references confirmed accurate. Gaps addressed 
 ### Task 5.1: Update README with CAN usage
 **Validation**: README shows CAN examples
 
-- [ ] Add CAN to supported transports list
-- [ ] Add CLI usage examples
-- [ ] Document vcan setup for testing
-- [ ] Note Linux-only limitation
+- [x] Add CAN to supported transports list
+- [x] Add CLI usage examples
+- [x] Document vcan setup for testing
+- [x] Note Linux-only limitation
 
 ### Task 5.2: Close GitHub issue #39
 **Validation**: Issue #39 closed with implementation summary


### PR DESCRIPTION
## Summary
- Add `-c`/`--can` CLI argument for SocketCAN input (Phase 3)
- Create `test_can.sh` integration test with 7 tests and CI workflow support for Linux (Phase 4)
- Update README with CAN Bus transport documentation, examples, and vcan setup guide (Phase 5)
- Builds on Phases 1-2 (CMake build system + CCanDevice class) already on master

Relates to #39

## Test plan
- [ ] Verify `-c vcan0 -j` CLI argument is accepted (Linux with SocketCAN)
- [ ] Verify helpful error when not compiled with `-DENABLE_SOCKETCAN=ON`
- [ ] Verify `test_can.sh` passes on Linux CI runners
- [ ] Verify Windows/macOS CI jobs are unaffected
- [ ] Verify README CAN section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI input path and Linux-only CI setup that depends on kernel modules/sudo, which could introduce input-selection edge cases or CI flakiness despite being feature-gated behind `HAVE_SOCKETCAN`/`ENABLE_SOCKETCAN`.
> 
> **Overview**
> Adds Linux SocketCAN as a new *optional* CLI input source: `src/main/asterix.cpp` introduces `-c/--can/--socketcan`, updates help text, and wires CAN into `buildInputString()` (guarded by `HAVE_SOCKETCAN`, with a clear rebuild error when disabled).
> 
> Extends Linux CI to exercise SocketCAN by installing `iproute2`, provisioning a `vcan0` interface when available, configuring CMake with `-DENABLE_SOCKETCAN=ON` only in that case, running a new `install/test/test_can.sh` integration script, and cleaning up the interface afterward. README and the openspec task tracker are updated with CAN usage/build instructions and limitations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ed1a422934957ab7d9ab1cdf41c07bedf1e680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->